### PR TITLE
Add TextFormatter support to bio

### DIFF
--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -32,6 +32,6 @@ app.initializers.add('fof-user-bio', () => {
       label: app.translator.trans('fof-user-bio.admin.setting.bioLimit'),
       setting: 'fof-user-bio.maxLength',
       type: 'number',
-      placeholder: 200
+      placeholder: 200,
     });
 });

--- a/js/src/forum/components/UserBio.js
+++ b/js/src/forum/components/UserBio.js
@@ -56,12 +56,18 @@ export default class UserBio extends Component {
       let subContent;
 
       if (this.loading) {
-        subContent = <p className="UserBio-placeholder">{LoadingIndicator.component({ size: 'tiny' })}</p>;
+        subContent = (
+          <p className="UserBio-placeholder">
+            <LoadingIndicator />
+          </p>
+        );
       } else {
         const bioHtml = user.bioHtml();
 
         if (bioHtml) {
           subContent = m.trust(bioHtml);
+        } else if (user.bio()) {
+          subContent = m.trust('<p>' + $('<div/>').text(user.bio()).html().replace(/\n/g, '<br>').autoLink({ rel: 'nofollow ugc' }) + '</p>');
         } else if (editable) {
           subContent = <p className="UserBio-placeholder">{this.bioPlaceholder}</p>;
         }

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -11,9 +11,7 @@ export * from './components';
 
 app.initializers.add('fof-user-bio', () => {
   User.prototype.bio = Model.attribute('bio');
-  User.prototype.bioHtml = computed('bio', (bio) =>
-    bio ? '<p>' + $('<div/>').text(bio).html().replace(/\n/g, '<br>').autoLink({ rel: 'nofollow ugc' }) + '</p>' : ''
-  );
+  User.prototype.bioHtml = Model.attribute('bioHtml');
 
   extend(UserCard.prototype, 'infoItems', function (items) {
     let user = this.attrs.user;

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -27,6 +27,11 @@
         font-size: 14px;
         resize: none;
     }
+
+    .LoadingIndicator-container {
+        color: white;
+        height: 50px;
+    }
 }
 
 .UserBio-content {

--- a/src/Listeners/AddUserBioAttribute.php
+++ b/src/Listeners/AddUserBioAttribute.php
@@ -15,7 +15,6 @@ use Flarum\Api\Serializer\UserSerializer;
 use Flarum\Formatter\Formatter;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
-use Illuminate\Support\Str;
 
 class AddUserBioAttribute
 {

--- a/src/Listeners/AddUserBioAttribute.php
+++ b/src/Listeners/AddUserBioAttribute.php
@@ -46,7 +46,7 @@ class AddUserBioAttribute
         $actor = $serializer->getActor();
 
         $bio = $user->bio ?? '';
-        $isXML = str_starts_with($bio, '<');
+        $isXML = Str::startsWith($bio, '<');
 
         $canViewBio = $actor->can('viewBio', $user);
         $canEditBio = $actor->can('editBio', $user);

--- a/src/Listeners/AddUserBioAttribute.php
+++ b/src/Listeners/AddUserBioAttribute.php
@@ -48,22 +48,25 @@ class AddUserBioAttribute
         $bio = $user->bio ?? '';
         $isXML = str_starts_with($bio, '<');
 
-        if ($actor->can('viewBio', $user)) {
+        $canViewBio = $actor->can('viewBio', $user);
+        $canEditBio = $actor->can('editBio', $user);
+
+        if ($canViewBio) {
             if ($isXML) {
                 $attributes['bioHtml'] = $this->formatter->render($bio);
 
-                if ($actor->id === $user->id) {
+                if ($canEditBio) {
                     $attributes['bio'] = $this->formatter->unparse($bio);
                 }
             } else {
                 $attributes['bio'] = $bio;
             }
-
-            $attributes += [
-                'canViewBio' => true,
-                'canEditBio' => $actor->can('editBio', $user),
-            ];
         }
+
+        $attributes += [
+            'canViewBio' => $canViewBio,
+            'canEditBio' => $canEditBio,
+        ];
 
         return $attributes;
     }

--- a/src/Listeners/SaveUserBio.php
+++ b/src/Listeners/SaveUserBio.php
@@ -11,6 +11,7 @@
 
 namespace FoF\UserBio\Listeners;
 
+use Flarum\Formatter\Formatter;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Event\Saving;
 use FoF\UserBio\Event\BioChanged;
@@ -24,9 +25,15 @@ class SaveUserBio
      */
     protected $settings;
 
-    public function __construct(SettingsRepositoryInterface $settings)
+    /**
+     * @var Formatter
+     */
+    protected $formatter;
+
+    public function __construct(SettingsRepositoryInterface $settings, Formatter $formatter)
     {
         $this->settings = $settings;
+        $this->formatter = $formatter;
     }
 
     /**
@@ -45,7 +52,7 @@ class SaveUserBio
         if (isset($attributes['bio'])) {
             $actor->assertCan('editBio', $user);
 
-            $user->bio = Str::limit($attributes['bio'], $this->settings->get('fof-user-bio.maxLength'), '');
+            $user->bio = $this->formatter->parse(Str::limit($attributes['bio'], $this->settings->get('fof-user-bio.maxLength'), ''));
 
             $user->raise(new BioChanged($user));
 

--- a/src/Listeners/SaveUserBio.php
+++ b/src/Listeners/SaveUserBio.php
@@ -17,7 +17,6 @@ use Flarum\User\Event\Saving;
 use FoF\UserBio\Event\BioChanged;
 use FoF\UserBio\Validators\UserBioValidator;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 
 class SaveUserBio
 {

--- a/src/Validators/UserBioValidator.php
+++ b/src/Validators/UserBioValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/user-bio.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\UserBio\Validators;
 
 use Flarum\Foundation\AbstractValidator;
@@ -29,7 +38,7 @@ class UserBioValidator extends AbstractValidator
         return [
             'bio' => [
                 'string',
-                'max:' . $this->settings->get('fof-user-bio.maxLength')
+                'max:'.$this->settings->get('fof-user-bio.maxLength'),
             ],
         ];
     }

--- a/src/Validators/UserBioValidator.php
+++ b/src/Validators/UserBioValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace FoF\UserBio\Validators;
+
+use Flarum\Foundation\AbstractValidator;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Validation\Factory;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class UserBioValidator extends AbstractValidator
+{
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    public function __construct(Factory $validator, TranslatorInterface $translator, SettingsRepositoryInterface $settings)
+    {
+        parent::__construct($validator, $translator);
+
+        $this->settings = $settings;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getRules()
+    {
+        return [
+            'bio' => [
+                'string',
+                'max:' . $this->settings->get('fof-user-bio.maxLength')
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #37**

**Changes proposed in this pull request:**
- Add TextFormatter support
- Keeps support for old bios that aren't XML (i.e. TextFormatter) insteda of having to parse all
- Can't trim `bio` now in serializer as that produces malformed XML

**Reviewers:**
All our other exts have a `setFormatter` and `getFormatter` method in the model class, but that isn't a thing here. Think just retrieving from container is fine?

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/178020995-8cca4d86-75e5-43cc-adfc-4c6ed1cd793e.png)
![image](https://user-images.githubusercontent.com/6401250/178020841-bed82c8d-b5e7-4893-b538-5af00130fe5b.png)

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).