### PR TITLE
Prevent line break spam & better error handling

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -39,6 +39,7 @@ return [
 
     (new Flarum\Settings())
         ->serializeToForum('fof-user-bio.maxLength', 'fof-user-bio.maxLength', 'intVal')
+        ->serializeToForum('fof-user-bio.maxLines', 'fof-user-bio.maxLines', 'intVal')
         ->default('fof-user-bio.maxLength', 200),
 
     (new Flarum\ServiceProvider())

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -35,6 +35,13 @@ app.initializers.add('fof-user-bio', () => {
       placeholder: 200,
     })
     .registerSetting({
+      label: app.translator.trans('fof-user-bio.admin.setting.maxLines'),
+      setting: 'fof-user-bio.maxLines',
+      type: 'number',
+      placeholder: 5,
+      min: 5,
+    })
+    .registerSetting({
       label: app.translator.trans('fof-user-bio.admin.setting.allowFormatting'),
       help: app.translator.trans('fof-user-bio.admin.setting.allowFormatting_help'),
       setting: 'fof-user-bio.allowFormatting',

--- a/js/src/forum/components/UserBio.js
+++ b/js/src/forum/components/UserBio.js
@@ -100,8 +100,10 @@ export default class UserBio extends Component {
         }
       }
 
+      const maxLines = app.forum.attribute('fof-user-bio.maxLines');
+
       content = (
-        <div className="UserBio-content" onclick={editable ? this.edit.bind(this) : () => undefined}>
+        <div className="UserBio-content" onclick={editable ? this.edit.bind(this) : () => undefined} style={{ '--bio-max-lines': maxLines }}>
           {subContent}
         </div>
       );

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -36,6 +36,10 @@
 
 .UserBio-content {
     padding: 10px 10px 1px;
+
+    line-height: 21px;
+    max-height: calc(~"1px + 20px + 21px * max(var(--bio-max-lines), 5)"); // padding + line-height * lines
+    overflow-y: auto;
 }
 
 .UserBio-placeholder {

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -6,6 +6,7 @@ fof-user-bio:
             editAny: Edit any bio
         setting:
             bioLimit: Bio character limit
+            maxLines: Max number of lines to show at a time
             allowFormatting: Allow formatting in bio
             allowFormatting_help: By design, this formatting is separate from post formatting. If the BBCode and/or Markdown extensions are enabled, they will be available to format the bio. No images or embeds are allowed. Extensions that add to the Flarum formatter must *explicitly* add support for the bio formatter.
 

--- a/src/Listeners/SaveUserBio.php
+++ b/src/Listeners/SaveUserBio.php
@@ -62,13 +62,16 @@ class SaveUserBio
 
             $this->validator->assertValid(Arr::only($attributes, 'bio'));
 
-            $user->bio = Str::of($attributes['bio'])->trim();
+            $bio = Str::of($attributes['bio'])->trim();
+            $bio = preg_replace('/\R{3,}/u', "\n\n", $bio);
 
             if ($allowFormatting) {
-                $user->bio = $this->formatter->parse($user->bio);
+                $user->bio = $this->formatter->parse($bio);
+            } else {
+                $user->bio = $bio;
             }
 
-            if ($user->bio != $user->getOriginal('bio')) {
+            if ($user->isDirty('bio')) {
                 $user->raise(new BioChanged($user));
             }
         }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Supersedes #52**

**Changes proposed in this pull request:**
- Trim 2+ line breaks to 2 max
- Add setting to configure max # of lines visible
- Improve error handling when user bio fails to save
  - If saving fails, user goes back to editing their bio
  - If failed when pressing enter to submit, will keep trying each time
  - If failed when blurring, will stop attempting if no changes are made and textarea loses focus again 

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~