### PR TITLE
fix: displayname not used

### DIFF
--- a/js/src/forum/components/UserBio.js
+++ b/js/src/forum/components/UserBio.js
@@ -39,7 +39,7 @@ export default class UserBio extends Component {
           app.translator.trans('fof-user-bio.forum.userbioPlaceholder')
         : // Special placeholder if someone else is viewing their profile with edit access
           app.translator.trans('fof-user-bio.forum.userbioPlaceholderOtherUser', {
-            username: this.attrs.user.username(),
+            username: this.attrs.user.displayName(),
           });
   }
 


### PR DESCRIPTION
When a DisplayName driver other than `username` is used, the helptext still displayed the username, rather than nickname (for example)