### PR TITLE
[2.x] fix: migrate GDPR data type to Flarum 2.x API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,11 +65,11 @@
         }
     },
     "require-dev": {
-        "flarum/bbcode": "2.x-dev",
-        "flarum/testing": "2.x-dev",
-        "flarum/phpstan": "2.x-dev",
-        "flarum/suspend": "2.x-dev",
-		"flarum/gdpr": "2.x-dev"
+        "flarum/bbcode": "^2.0.0",
+        "flarum/testing": "^2.0.0",
+        "flarum/phpstan": "^2.0.0",
+        "flarum/suspend": "^2.0.0",
+		"flarum/gdpr": "^2.0.0"
     },
     "autoload-dev": {
         "psr-4": {
@@ -94,6 +94,6 @@
         "test:setup": "Sets up a database for use with integration tests. Execute this only once.",
         "analyse:phpstan": "Run static analysis"
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "beta",
     "prefer-stable": true
 }

--- a/extend.php
+++ b/extend.php
@@ -54,6 +54,6 @@ return [
     (new Flarum\Conditional())
         ->whenExtensionEnabled('flarum-gdpr', fn () => [
             (new \Flarum\Gdpr\Extend\UserData())
-                ->addType(Gdpr\UserBioData::class),
+                ->addType(Data\UserBioData::class),
         ]),
 ];

--- a/src/Data/UserBioData.php
+++ b/src/Data/UserBioData.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace FoF\UserBio\Gdpr;
+namespace FoF\UserBio\Data;
 
-use Flarum\Gdpr\Contracts\DataType;
+use Flarum\Gdpr\Data\Type;
 use Flarum\Gdpr\Models\ErasureRequest;
 use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -19,7 +19,7 @@ use Flarum\User\User;
 use Illuminate\Contracts\Filesystem\Factory;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class UserBioData implements DataType
+class UserBioData extends Type
 {
     public function __construct(
         protected User $user,
@@ -38,41 +38,37 @@ class UserBioData implements DataType
 
     public function export(): ?array
     {
-        if (empty($this->user->bio)) {
-            return null;
-        }
-
-        return [
-            'user-bio/bio.json' => json_encode([
-                'bio' => $this->user->bio,
-            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
-        ];
+        // No action, data included in core user export
+        return null;
     }
 
     public function anonymize(): void
     {
-        $this->user->bio = null;
-        $this->user->save();
+        // No action, the user biography will be cleared by the core user data type
     }
 
     public function delete(): void
     {
-        $this->user->bio = null;
-        $this->user->save();
+        // Nothing to do, the user table row will be deleted by the core user data type
     }
 
     public static function exportDescription(): string
     {
-        return 'User biography text';
+        return static::staticTranslator()->trans('flarum-gdpr.lib.data.default_user_action');
     }
 
     public static function anonymizeDescription(): string
     {
-        return 'Remove user biography';
+        return static::staticTranslator()->trans('flarum-gdpr.lib.data.default_user_action');
     }
 
     public static function deleteDescription(): string
     {
-        return 'Remove user biography';
+        return static::staticTranslator()->trans('flarum-gdpr.lib.data.default_user_action');
+    }
+
+    public static function piiFields(): array
+    {
+        return ['bio'];
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `src/Gdpr/UserBioData.php` (1.x `DataType` interface) with `src/Data/UserBioData.php` (2.x `Type` base class)
- Declares `bio` as a PII field via `piiFields()` — the 2.x base class handles anonymize/delete automatically
- Relies on the core GDPR user table export for bio data (no separate export file needed)
- Updates `extend.php` reference from `Gdpr\UserBioData` to `Data\UserBioData`

## Test plan

- [ ] Enable `flarum-gdpr` extension alongside this one
- [ ] Submit a GDPR export request — verify bio data appears in the user table export
- [ ] Submit a GDPR anonymize request — verify `bio` column is cleared for the user
- [ ] Submit a GDPR delete request — verify `bio` column is cleared before user deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)